### PR TITLE
fix: improve delimiter escaping for double-quoted strings

### DIFF
--- a/expand_test.go
+++ b/expand_test.go
@@ -520,6 +520,49 @@ func TestReplaceYAMLWithExprRepFn(t *testing.T) {
 			},
 			false,
 			true,
+			`v: 'hello \{\{ {{ hello }} \}\}'`,
+			`v: 'hello {{ {"foo":"bar"} }}'`,
+		},
+		{
+			map[string]any{
+				"hello": map[string]any{
+					"foo": "bar",
+				},
+			},
+			false,
+			true,
+			`v: |-
+hello \{\{ name \}\}`,
+			`v: |-
+hello {{ name }}`,
+		},
+		{
+			map[string]any{
+				"vars": map[string]any{
+					"foo": "bar",
+				},
+			},
+			false,
+			true,
+			`/post:
+  post:
+    body:
+      application/json:
+        name: "Hello {{ vars.foo }} \\{\\{ name \\}\\}"`,
+			`/post:
+  post:
+    body:
+      application/json:
+        name: "Hello bar {{ name }}"`,
+		},
+		{
+			map[string]any{
+				"hello": map[string]any{
+					"foo": "bar",
+				},
+			},
+			false,
+			true,
 			`v: '\\{\{ hello \\}\}'`,
 			`v: '\{\{ hello \}\}'`,
 		},


### PR DESCRIPTION
This pull request introduces enhancements to the YAML interpolation and delimiter unescaping logic, along with expanded test coverage. The changes aim to improve handling of escaped delimiters and double-quoted strings, ensuring more robust functionality.

### Enhancements to delimiter handling:

* Modified `func unescapeDelims` in `repfn.go` to detect and handle double-quoted strings heuristically. Adjusted the escaping logic to account for double quotes by adding extra backslashes when necessary.

### Improvements to interpolation function:

* Updated `func ExprRepFn` in `repfn.go` to use named return values for better readability and consistency.

### Expanded test coverage:

* Added multiple test cases in `func TestReplaceYAMLWithExprRepFn` in `expand_test.go` to validate interpolation and escaping behavior for various YAML scenarios, including nested maps, multiline strings, and JSON-like structures.